### PR TITLE
Fix node indexing and resqml types

### DIFF
--- a/tests/warmth3d/test_3d.py
+++ b/tests/warmth3d/test_3d.py
@@ -61,7 +61,7 @@ def test_3d_compare():
         print("Total time 1D simulations:", runtime_1D_sim)
 
         pickle.dump( model, open( model_pickled, "wb" ) )
-        model = pickle.load( open( model_pickled, "rb" ) )
+        # model = pickle.load( open( model_pickled, "rb" ) )
         try:
             os.mkdir('mesh')
         except FileExistsError:

--- a/warmth/build.py
+++ b/warmth/build.py
@@ -720,11 +720,10 @@ class Builder:
                                                 'rhp': rhp, 'phi': phi, 'decay': decay, 'solidus': solidus, 'liquidus': liquidus,'strat':strat,'horizonIndex':inputRef})
                     df = df.sort_values(by=["topage"],ignore_index=True)
 
-    
+                    # print(df)
                     #df.reset_index(drop=True,inplace=True)
-                    df.at[2, 'top'] = np.nan
-            
-                    df.at[3, 'top'] = np.nan
+                    # df.at[2, 'top'] = np.nan            
+                    # df.at[3, 'top'] = np.nan
                     checker = self._check_nan_sed(df)
 
                     if checker is False:

--- a/warmth/forward_modelling.py
+++ b/warmth/forward_modelling.py
@@ -282,7 +282,8 @@ class Forward_model:
 
                 lower_idx = np.argwhere(coord_new > key_depth)
                 if lower_idx.size == 0:
-                    raise Exception
+                    # raise Exception
+                    lower_idx = len(coord_new)-1
                 else:
                     lower_idx = lower_idx[0][0]
 

--- a/warmth/mesh_model.py
+++ b/warmth/mesh_model.py
@@ -515,13 +515,10 @@ class UniformNodeGridFixedSizeMeshModel:
             return 0
 
 
-    def buildVertices(self, time_index=0, useFakeEncodedZ=False, optimized=False):
+    def buildVertices(self, time_index=0, optimized=False):
         """Determine vertex positions, node-by-node.
            For every node, the same number of vertices is added (one per sediment, one per crust, lith, asth, and one at the bottom)
            Degenerate vertices (e.g. at nodes where sediment is yet to be deposited or has been eroded) are avoided by a small shift, kept in self.sed_diff_z
-           
-           When the option useFakeEncodedZ is set, the z-values are repurposed to encode the index of the vertex in the original, deterministic indexing.
-           This is necessary because dolfinx will re-index the vertices upon mesh generation. 
         """           
         tti = time_index
         self.tti = time_index
@@ -548,14 +545,10 @@ class UniformNodeGridFixedSizeMeshModel:
                         zpos = xxT + base_of_current_sediments
                         aa = np.concatenate([aa,np.array([zpos])])
 
-            # zp = base_of_last_sediments+ (base_crust-base_of_last_sediments)*(i/self.numElemInCrust) 
             base_of_last_sediments = (xxT+self.bottom_sed_id_at_nodes[-1][:,tti]) if (len(self.bottom_sed_id_at_nodes)>0) else xxT
 
             for i in range(1,self.numElemInCrust+1):
                 zp = base_of_last_sediments+ (bc-base_of_last_sediments)*(i/self.numElemInCrust) 
-                # self.mesh_vertices_0.append( [ node.X, node.Y, base_of_last_sediments+ (base_crust-base_of_last_sediments)*(i/self.numElemInCrust) ] )
-                # self.sed_diff_z.append(0.0)
-                # self.mesh_vertices_age_unsorted.append(1000)
                 aa = np.concatenate([aa,np.array([zp])])
 
             for i in range(1,self.numElemInLith+1):
@@ -595,8 +588,6 @@ class UniformNodeGridFixedSizeMeshModel:
                         self.sed_diff_z.append(-self.minimumCellThick*(self.numberOfSedimentCells - (ss*self.numElemPerSediment+j) ))
                         age_of_previous = node.sediments.baseage[ss-1] if (ss>0) else 0.0
                         self.mesh_vertices_age_unsorted.append( age_of_previous + ((j+1) / self.numElemPerSediment) * (node.sediments.baseage[ss]-age_of_previous) )  # append interpolatedbase age of current sediment
-                # if (ind==97) and (tti==0):
-                #     breakpoint()
                 if (ind==0):
                     delta = time.time() - st
                     print("delta 2", delta)
@@ -630,8 +621,6 @@ class UniformNodeGridFixedSizeMeshModel:
             self.sed_diff_z = np.array(self.sed_diff_z)
             self.mesh_vertices = self.mesh_vertices_0.copy()
         self.mesh_vertices[:,2] = self.mesh_vertices_0[:,2] + self.sed_diff_z
-        if (useFakeEncodedZ):
-            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*1000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.01
 
     def updateVertices(self):
         """Update the mesh vertex positions using the values in self.mesh_vertices, and using the known dolfinx-induded reindexing
@@ -651,7 +640,7 @@ class UniformNodeGridFixedSizeMeshModel:
         """Construct a new mesh at the given time index tti, and determine the vertex re-indexing induced by dolfinx
         """        
         self.tti = tti
-        self.buildVertices(time_index=tti, useFakeEncodedZ=True)
+        self.buildVertices(time_index=tti)
         logger.info("Built vertices")
         self.constructMesh()
         logger.info("Built mesh")
@@ -665,7 +654,7 @@ class UniformNodeGridFixedSizeMeshModel:
         import time
         assert self.mesh is not None
         self.tti = tti        
-        self.buildVertices(time_index=tti, useFakeEncodedZ=False, optimized=optimized)
+        self.buildVertices(time_index=tti, optimized=optimized)
         self.updateVertices()        
         self.posarr.append(self.mesh.geometry.x.copy())
         self.time_indices.append(self.tti)
@@ -789,10 +778,8 @@ class UniformNodeGridFixedSizeMeshModel:
         mpi_print(f"Dir local verts: {dir(self.mesh.topology.index_map(0))}")  # local_to_global ! ?
         mpi_print(f"Type local verts: {type(self.mesh.topology.index_map(0))}")
 
-        # obtain original vertex order as encoded in z-pos digits
-        zz  = self.mesh.geometry.x[:,2].copy()
-        zz2 = np.mod(zz,1000)
-        self.mesh_reindex = (1e-4+zz2*100).astype(np.int32)
+        # store original vertex order 
+        self.mesh_reindex = np.array(self.mesh.geometry.input_global_indices).astype(np.int32)
         self.mesh0_geometry_x = self.mesh.geometry.x.copy()
 
 

--- a/warmth/resqpy_helpers.py
+++ b/warmth/resqpy_helpers.py
@@ -382,7 +382,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
 
     if Temp_per_vertex is not None:
         _ = rqp.Property.from_array(model,
-                                    Temp_per_vertex,
+                                    Temp_per_vertex.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Temperature',
                                     support_uuid = hexa.uuid,
@@ -392,7 +392,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
 
     if age_per_vertex is not None:
         _ = rqp.Property.from_array(model,
-                                    age_per_vertex,
+                                    age_per_vertex.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Age',
                                     support_uuid = hexa.uuid,
@@ -413,7 +413,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
          
     if poro0_per_cell is not None:
         _ = rqp.Property.from_array(model,
-                                    poro0_per_cell,
+                                    poro0_per_cell.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Porosity_initial',
                                     support_uuid = hexa.uuid,
@@ -422,7 +422,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
                                     uom = 'm3/m3')
     if decay_per_cell is not None:
         _ = rqp.Property.from_array(model,
-                                    decay_per_cell,
+                                    decay_per_cell.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Porosity_decay',
                                     support_uuid = hexa.uuid,
@@ -431,7 +431,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
                                     uom = 'Euc')
     if density_per_cell is not None:
         _ = rqp.Property.from_array(model,
-                                    density_per_cell,
+                                    density_per_cell.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Density_solid',
                                     support_uuid = hexa.uuid,
@@ -443,7 +443,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
         # we write thermal conductivity as its inverse, the thermal insulance
         #
         _ = rqp.Property.from_array(model,
-                                    np.reciprocal(cond_per_cell),
+                                    np.reciprocal(cond_per_cell).astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'insulance_thermal',
                                     support_uuid = hexa.uuid,
@@ -452,7 +452,7 @@ def write_hexa_grid_with_properties(filename, nodes, cells, modelTitle = "hexame
                                     uom = 'deltaK.m2/W')
     if rhp_per_cell is not None:
         _ = rqp.Property.from_array(model,
-                                    rhp_per_cell,
+                                    rhp_per_cell.astype(np.float32),
                                     source_info = 'SubsHeat',
                                     keyword = 'Radiogenic_heat_production',
                                     support_uuid = hexa.uuid,
@@ -563,7 +563,7 @@ def write_hexa_grid_with_timeseries(filename, nodes_series, cells, modelTitle = 
     # nodes0 = nodes.copy()
     for time_index in range(len(nodes_series)-1,-1,-1):
         # nodes2 = nodes0 + [0,0,time_index*10]
-        nodes2 = nodes_series[time_index]
+        nodes2 = nodes_series[time_index].astype(np.float32)
         pc.add_cached_array_to_imported_list(nodes2,
                                                 'dynamic nodes',
                                                 'points',
@@ -574,7 +574,7 @@ def write_hexa_grid_with_timeseries(filename, nodes_series, cells, modelTitle = 
                                                 indexable_element = 'nodes',
                                                 points = True)
         # active_array = np.ones([2160], dtype = bool)
-        tt = Temp_per_vertex_series[time_index]
+        tt = Temp_per_vertex_series[time_index].astype(np.float32)
         pc.add_cached_array_to_imported_list(tt,
                                                 'Temperature',
                                                 'Temperature',

--- a/warmth3d/fixed_mesh_model.py
+++ b/warmth3d/fixed_mesh_model.py
@@ -488,7 +488,7 @@ class UniformNodeGridFixedSizeMeshModel:
         self.mesh_vertices = self.mesh_vertices_0.copy()
         self.mesh_vertices[:,2] = self.mesh_vertices_0[:,2] + self.sed_diff_z
         if (useFakeEncodedZ):
-            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*1000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.01
+            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*1000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.001
             # zz = self.mesh_vertices[:,2].copy()
             # zz2=np.mod(zz,1000)
             # # mesh_reindex = (1e-4+zz2*10).astype(np.int32)
@@ -675,7 +675,7 @@ class UniformNodeGridFixedSizeMeshModel:
         # obtain original vertex order as encoded in z-pos digits
         zz  = self.mesh.geometry.x[:,2].copy()
         zz2 = np.mod(zz,1000)
-        self.mesh_reindex = (1e-4+zz2*100).astype(np.int32)
+        self.mesh_reindex = (1e-4+zz2*1000).astype(np.int32)
         self.mesh0_geometry_x = self.mesh.geometry.x.copy()
 
         # for i,c in enumerate(self.node_index):

--- a/warmth3d/fixed_mesh_model.py
+++ b/warmth3d/fixed_mesh_model.py
@@ -421,13 +421,11 @@ class UniformNodeGridFixedSizeMeshModel:
         return 0
 
 
-    def buildVertices(self, time_index=0, useFakeEncodedZ=False):
+    def buildVertices(self, time_index=0):
         """Determine vertex positions, node-by-node.
            For every node, the same number of vertices is added (one per sediment, one per crust, lith, asth, and one at the bottom)
            Degenerate vertices (e.g. at nodes where sediment is yet to be deposited or has been eroded) are avoided by a small shift, kept in self.sed_diff_z
            
-           When the option useFakeEncodedZ is set, the z-values are repurposed to encode the index of the vertex in the original, deterministic indexing.
-           This is necessary because dolfinx will re-index the vertices upon mesh generation. 
         """           
         tti = time_index
         self.tti = time_index
@@ -487,11 +485,7 @@ class UniformNodeGridFixedSizeMeshModel:
         self.sed_diff_z = np.array(self.sed_diff_z)
         self.mesh_vertices = self.mesh_vertices_0.copy()
         self.mesh_vertices[:,2] = self.mesh_vertices_0[:,2] + self.sed_diff_z
-        if (useFakeEncodedZ):
-            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*1000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.001
-            # zz = self.mesh_vertices[:,2].copy()
-            # zz2=np.mod(zz,1000)
-            # # mesh_reindex = (1e-4+zz2*10).astype(np.int32)
+
 
     def updateVertices(self):
         """Update the mesh vertex positions using the values in self.mesh_vertices, and using the known dolfinx-induded reindexing
@@ -509,9 +503,8 @@ class UniformNodeGridFixedSizeMeshModel:
         """Construct a new mesh at the given time index tti, and determine the vertex re-indexing induced by dolfinx
         """        
         self.tti = tti
-        self.buildVertices(time_index=tti, useFakeEncodedZ=True)
+        self.buildVertices(time_index=tti)
         self.constructMesh()
-        self.buildVertices(time_index=tti, useFakeEncodedZ=False)
         self.updateVertices()        
 
     def updateMesh(self,tti):
@@ -519,7 +512,7 @@ class UniformNodeGridFixedSizeMeshModel:
         """   
         assert self.mesh is not None
         self.tti = tti
-        self.buildVertices(time_index=tti, useFakeEncodedZ=False)
+        self.buildVertices(time_index=tti)
         self.updateVertices()        
 
     def buildHexahedra(self):
@@ -672,10 +665,8 @@ class UniformNodeGridFixedSizeMeshModel:
         # breakpoint()
 
         #
-        # obtain original vertex order as encoded in z-pos digits
-        zz  = self.mesh.geometry.x[:,2].copy()
-        zz2 = np.mod(zz,1000)
-        self.mesh_reindex = (1e-4+zz2*1000).astype(np.int32)
+        # obtain original vertex order
+        self.mesh_reindex = np.array(self.mesh.geometry.input_global_indices).astype(np.int32)        
         self.mesh0_geometry_x = self.mesh.geometry.x.copy()
 
         # for i,c in enumerate(self.node_index):

--- a/warmth3d/sed_only_mesh_model.py
+++ b/warmth3d/sed_only_mesh_model.py
@@ -361,7 +361,7 @@ class UniformNodeGridFixedSizeMeshModel:
         self.mesh_vertices = self.mesh_vertices_0.copy()
         self.mesh_vertices[:,2] = self.mesh_vertices_0[:,2] + self.sed_diff_z
         if (useFakeEncodedZ):
-            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*1000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.01
+            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*10000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.001
             # zz = self.mesh_vertices[:,2].copy()
             # zz2=np.mod(zz,1000)
             # # mesh_reindex = (1e-4+zz2*10).astype(np.int32)
@@ -534,8 +534,8 @@ class UniformNodeGridFixedSizeMeshModel:
         #
         # obtain original vertex order as encoded in z-pos digits
         zz  = self.mesh.geometry.x[:,2].copy()
-        zz2 = np.mod(zz,1000)
-        self.mesh_reindex = (1e-4+zz2*100).astype(np.int32)
+        zz2 = np.mod(zz,10000)
+        self.mesh_reindex = (1e-4+zz2*1000).astype(np.int32)
         self.mesh0_geometry_x = self.mesh.geometry.x.copy()
 
     def normalizedZ(self, z):

--- a/warmth3d/sed_only_mesh_model.py
+++ b/warmth3d/sed_only_mesh_model.py
@@ -297,13 +297,11 @@ class UniformNodeGridFixedSizeMeshModel:
         return self.parameters1D.kCrust
 
 
-    def buildVertices(self, time_index=0, useFakeEncodedZ=False):
+    def buildVertices(self, time_index=0):
         """Determine vertex positions, node-by-node.
            For every node, the same number of vertices is added (one per sediment, one per crust, lith, asth, and one at the bottom)
            Degenerate vertices (e.g. at nodes where sediment is yet to be deposited or has been eroded) are avoided by a small shift, kept in self.sed_diff_z
            
-           When the option useFakeEncodedZ is set, the z-values are repurposed to encode the index of the vertex in the original, deterministic indexing.
-           This is necessary because dolfinx will re-index the vertices upon mesh generation. 
         """           
         tti = time_index
         self.tti = time_index
@@ -360,11 +358,6 @@ class UniformNodeGridFixedSizeMeshModel:
         self.sed_diff_z = np.array(self.sed_diff_z)
         self.mesh_vertices = self.mesh_vertices_0.copy()
         self.mesh_vertices[:,2] = self.mesh_vertices_0[:,2] + self.sed_diff_z
-        if (useFakeEncodedZ):
-            self.mesh_vertices[:,2] = np.ceil(self.mesh_vertices[:,2])*10000 + np.array(list(range(self.mesh_vertices.shape[0])))*0.001
-            # zz = self.mesh_vertices[:,2].copy()
-            # zz2=np.mod(zz,1000)
-            # # mesh_reindex = (1e-4+zz2*10).astype(np.int32)
 
     def updateVertices(self):
         """Update the mesh vertex positions using the values in self.mesh_vertices, and using the known dolfinx-induded reindexing
@@ -381,9 +374,8 @@ class UniformNodeGridFixedSizeMeshModel:
         """Construct a new mesh at the given time index tti, and determine the vertex re-indexing induced by dolfinx
         """        
         self.tti = tti
-        self.buildVertices(time_index=tti, useFakeEncodedZ=True)
+        self.buildVertices(time_index=tti)
         self.constructMesh()
-        self.buildVertices(time_index=tti, useFakeEncodedZ=False)
         self.updateVertices()        
 
     def updateMesh(self,tti):
@@ -391,7 +383,7 @@ class UniformNodeGridFixedSizeMeshModel:
         """   
         assert self.mesh is not None
         self.tti = tti
-        self.buildVertices(time_index=tti, useFakeEncodedZ=False)
+        self.buildVertices(time_index=tti)
         self.updateVertices()        
 
     def buildHexahedra(self):
@@ -532,10 +524,8 @@ class UniformNodeGridFixedSizeMeshModel:
             self.cell_data_layerID = aa.values.copy()
 
         #
-        # obtain original vertex order as encoded in z-pos digits
-        zz  = self.mesh.geometry.x[:,2].copy()
-        zz2 = np.mod(zz,10000)
-        self.mesh_reindex = (1e-4+zz2*1000).astype(np.int32)
+        # obtain original vertex order
+        self.mesh_reindex = np.array(self.mesh.geometry.input_global_indices).astype(np.int32)        
         self.mesh0_geometry_x = self.mesh.geometry.x.copy()
 
     def normalizedZ(self, z):


### PR DESCRIPTION
Proposed fix to types of property arrays in EPC and HFD5 file: indicate float64 in EPC, but write float32 to HDF5.  This is because RESQML apparently supports only double precision floats, but float32 is sufficient precision and uses less disk space.
Recover the node reindexing properly from dolfinx (instead of encoding the indices in the positions).  